### PR TITLE
♻️ [Refactor] : QueryDSL 쿼리에 정렬 조건 추가

### DIFF
--- a/src/main/java/umc7/spring/repository/MissionRepositoryImpl.java
+++ b/src/main/java/umc7/spring/repository/MissionRepositoryImpl.java
@@ -1,18 +1,23 @@
+
 package umc7.spring.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import umc7.spring.domain.Mission;
 import umc7.spring.domain.QMission;
 import umc7.spring.domain.QStore;
 import umc7.spring.domain.mappings.QMissionComplete;
-import umc7.spring.repository.MissionRepositoryCustom;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -30,9 +35,14 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
         }
         builder.and(missionComplete.member.id.eq(memberId));
 
+        OrderSpecifier<?> defaultSort = mission.createdAt.desc();
+        OrderSpecifier<?>[] sortOrders = getOrderSpecifiers(pageable, defaultSort);
+
+
         List<Mission> missions =  jpaQueryFactory.selectFrom(mission)
                 .leftJoin(mission.missionCompleteList, missionComplete)
                 .where(builder)
+                .orderBy(sortOrders)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -74,4 +84,19 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
         return new PageImpl<>(missions, pageable, total);
 
     }
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable, OrderSpecifier<?> defaultSort){
+        if (pageable.getSort().isSorted()) {
+            return pageable.getSort().stream()
+                    .map(order -> createOrderSpecifier(order))
+                    .toArray(OrderSpecifier[]::new);
+        }
+        return new OrderSpecifier<?>[] {defaultSort};
+    }
+    private OrderSpecifier<?> createOrderSpecifier(Sort.Order order) {
+        return new OrderSpecifier<>(
+                order.isAscending() ? Order.ASC : Order.DESC,
+                Expressions.path(LocalDateTime.class, mission, order.getProperty())
+        );
+    }
 }
+


### PR DESCRIPTION
### 이슈 번호 , 내용
**close #31** 

현재 Query DSL을 사용해서 미션 데이터를 조회할때, 정렬 조건이 없어서 클라이언트가 요청하는 정렬 기준을 처리할 수 없었습니다. 이에 따라 정렬 조건을 지원하도록 코드를 수정하였습니다.
### 작업 내용

- Pageable 객체의 정렬 조건을 QueryDSL의 orderBy 메서드에 매핑하였습니다.
- 동적 정렬을 지원하기 위해 OrderSpecifier  생성로직을 별도의 메서드로 추출하였습니다.
- 정렬 조건이 없는 경우 기본 정렬 조건으로 createdAt DESC 를 사용하였습니다.

